### PR TITLE
Simplify ListDescriptor class

### DIFF
--- a/ShoppingList/ListDescriptor.cpp
+++ b/ShoppingList/ListDescriptor.cpp
@@ -55,14 +55,14 @@ char* ListDescriptor::setString(char** m_str, const char* i_str)
 // -----------
 // Constructor
 // -----------
-ListDescriptor::ListDescriptor(const char* name, int nameLength, const char* description, int descLength)
+ListDescriptor::ListDescriptor(const char* name, const char* description)
 {
 	this->m_name = nullptr;
 	this->m_description = nullptr;
 	try
 	{
-		this->setName(name, nameLength);
-		this->setDescription(description, descLength);
+		this->setName(name);
+		this->setDescription(description);
 	}
 	catch (std::exception setNameException)
 	{
@@ -98,11 +98,6 @@ char* ListDescriptor::setName(char* name)
 	return temp;
 }
 
-char* ListDescriptor::setName(const char* name, int length)
-{
-	return setString(&this->m_name, name, length);
-}
-
 char* ListDescriptor::setName(const char* name)
 {
 	return setString(&this->m_name, name);
@@ -120,11 +115,6 @@ char* ListDescriptor::setDescription(char* description)
 	char* temp{ this->m_description };
 	this->m_description = description;
 	return temp;
-}
-
-char* ListDescriptor::setDescription(const char* description, int length)
-{
-	return setString(&this->m_description, description, length);
 }
 
 char* ListDescriptor::setDescription(const char* description)

--- a/ShoppingList/ListDescriptor.cpp
+++ b/ShoppingList/ListDescriptor.cpp
@@ -20,7 +20,7 @@ char* ListDescriptor::setString(char** m_str, const char* i_str, int length)
 	{
 		if (length < 1)
 		{
-			throw new std::invalid_argument("ListItem->string length should not be less than 1.");
+			throw new std::invalid_argument("ListDescriptor->string length should not be less than 1.");
 		}
 		else
 		{

--- a/ShoppingList/ListDescriptor.cpp
+++ b/ShoppingList/ListDescriptor.cpp
@@ -43,7 +43,11 @@ char* ListDescriptor::setString(char** m_str, const char* i_str)
 	int length{ 0 };
 	if (i_str != nullptr)
 	{
-		while (i_str[length++] != '\0') {}
+		while (i_str[length] != '\0')
+		{
+			length++;
+		}
+		length++;
 	}
 	return setString(m_str, i_str, length);
 }

--- a/ShoppingList/ListItem.cpp
+++ b/ShoppingList/ListItem.cpp
@@ -13,8 +13,8 @@ unsigned int ListItem::kDefaultItemQuantity = 1;
 // ------------
 // Constructors
 // ------------
-ListItem::ListItem(const char* name, int nameLength, const char* description, int descLength, unsigned int quantity, Category category) :
-	ListDescriptor(name, nameLength, description, descLength)
+ListItem::ListItem(const char* name, const char* description, unsigned int quantity, Category category) :
+	ListDescriptor(name, description)
 {
 	// Quantity
 	this->m_quantity = quantity;
@@ -24,19 +24,19 @@ ListItem::ListItem(const char* name, int nameLength, const char* description, in
 }
 
 // Name, quantity, category provided
-ListItem::ListItem(const char* name, int nameLength, unsigned int quantity, Category category) :
-	ListItem(name, nameLength, static_cast<const char*>(nullptr), 0, quantity, category){}
+ListItem::ListItem(const char* name, unsigned int quantity, Category category) :
+	ListItem(name, static_cast<const char*>(nullptr), quantity, category) {}
 
 // Name, quantity provided
-ListItem::ListItem(const char* name, int nameLength, unsigned int quantity) :
-	ListItem(name, nameLength, static_cast<const char*>(nullptr), 0, quantity, Category::NONE) {}
+ListItem::ListItem(const char* name, unsigned int quantity) :
+	ListItem(name, static_cast<const char*>(nullptr), quantity, Category::NONE) {}
 
 // Name provided
-ListItem::ListItem(const char* name, int nameLength) :
-	ListItem(name, nameLength, static_cast<const char*>(nullptr), 0, ListItem::kDefaultItemQuantity, Category::NONE) {}
+ListItem::ListItem(const char* name) :
+	ListItem(name, static_cast<const char*>(nullptr), ListItem::kDefaultItemQuantity, Category::NONE) {}
 
 ListItem::ListItem(void) :
-	ListItem(static_cast<const char*>(nullptr), 0, static_cast<const char*>(nullptr), 0, ListItem::kDefaultItemQuantity, Category::NONE) {}
+	ListItem(static_cast<const char*>(nullptr), static_cast<const char*>(nullptr), ListItem::kDefaultItemQuantity, Category::NONE) {}
 
 // -------------------
 // Getters and Setters

--- a/ShoppingList/ShoppingList.cpp
+++ b/ShoppingList/ShoppingList.cpp
@@ -7,7 +7,7 @@
 int main(void)
 {
 	ListItem* li = new ListItem();
-	li->setName("Avocado", 8);
+	li->setName("Avocado");
 	std::cout << li->getName() << '\n';
 	li->setName("Hass Avocado");
 	std::cout << li->getName() << '\n';

--- a/ShoppingList/ShoppingList.h
+++ b/ShoppingList/ShoppingList.h
@@ -35,15 +35,15 @@ protected:
 	// Getters and Setters
 	// -------------------
 public:
-	virtual char* getName(void);
-	virtual char* setName(char* name);
-	virtual char* setName(const char* name, int length);
-	virtual char* setName(const char* name);
+	char* getName(void);
+	char* setName(char* name);
+	char* setName(const char* name, int length);
+	char* setName(const char* name);
 
-	virtual char* getDescription(void);
-	virtual char* setDescription(char* description);
-	virtual char* setDescription(const char* description, int length);
-	virtual char* setDescription(const char* description);
+	char* getDescription(void);
+	char* setDescription(char* description);
+	char* setDescription(const char* description, int length);
+	char* setDescription(const char* description);
 };
 
 

--- a/ShoppingList/ShoppingList.h
+++ b/ShoppingList/ShoppingList.h
@@ -24,7 +24,7 @@ protected:
 	// -----------
 	// Constructor
 	// -----------
-	ListDescriptor(const char* name, int nameLength, const char* description, int descLength);
+	ListDescriptor(const char* name, const char* description);
 
 	// ----------
 	// Destructor
@@ -37,12 +37,10 @@ protected:
 public:
 	char* getName(void);
 	char* setName(char* name);
-	char* setName(const char* name, int length);
 	char* setName(const char* name);
 
 	char* getDescription(void);
 	char* setDescription(char* description);
-	char* setDescription(const char* description, int length);
 	char* setDescription(const char* description);
 };
 
@@ -82,11 +80,10 @@ private:
 	// Constructors
 	// ------------
 public:
-	ListItem(const char* name, int nameLength, const char* description, int descLength,
-		unsigned int quantity, Category category);
-	ListItem(const char* name, int nameLength, unsigned int quantity, Category category);
-	ListItem(const char* name, int nameLength, unsigned int quantity);
-	ListItem(const char* name, int nameLength);
+	ListItem(const char* name, const char* description, unsigned int quantity, Category category);
+	ListItem(const char* name, unsigned int quantity, Category category);
+	ListItem(const char* name, unsigned int quantity);
+	ListItem(const char* name);
 	ListItem(void);
 
 	// -------------------


### PR DESCRIPTION
Removes NameLength and DescLength fields from ListDescriptor class. Hoping this will make things easier to debug while implementing the List class.